### PR TITLE
Add isMajorScale and isMinorScale functions

### DIFF
--- a/src/isMajorScale/index.js
+++ b/src/isMajorScale/index.js
@@ -1,0 +1,27 @@
+// @flow
+
+import isDiatonicScale from '../isDiatonicScale';
+import normalizeScale from '../normalizeScale';
+import getIntervals from '../getIntervals';
+import IONIAN from '../constants/Mode/IONIAN';
+
+type options = {
+  direction?: direction
+};
+
+const isMajorScale = (scale: Scale, { direction = 1 }: options = {}) => {
+  if (![-1, 1].includes(direction)) {
+    throw new Error('Direction should be 1 (up) or -1 (down)');
+  }
+
+  if (!isDiatonicScale(scale)) return false;
+
+  if (direction === -1) scale.reverse();
+
+  const normalizedScale = normalizeScale(scale);
+  const intervals = getIntervals(normalizedScale);
+
+  return IONIAN.join(',') === intervals.join(',');
+};
+
+export default isMajorScale;

--- a/src/isMajorScale/test.js
+++ b/src/isMajorScale/test.js
@@ -1,0 +1,18 @@
+// https://en.wikipedia.org/wiki/Major_scale
+
+import isMajorScale from './';
+
+describe('isMajorScale', () => {
+  it('should return true on major scale ', () => {
+    const scale = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+    expect(isMajorScale(scale)).toBe(true);
+  });
+  it('should return true on major scale', () => {
+    const scale = ['C1', 'D1', 'E1', 'F1', 'G1', 'A1', 'B1'];
+    expect(isMajorScale(scale)).toBe(true);
+  });
+  it('should return false on minor scale ', () => {
+    const scale = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+    expect(isMajorScale(scale)).toBe(false);
+  });
+});

--- a/src/isMinorScale/index.js
+++ b/src/isMinorScale/index.js
@@ -1,0 +1,27 @@
+// @flow
+
+import isDiatonicScale from '../isDiatonicScale';
+import normalizeScale from '../normalizeScale';
+import getIntervals from '../getIntervals';
+import AEOLIAN from '../constants/Mode/AEOLIAN';
+
+type options = {
+  direction?: direction
+};
+
+const isMinorScale = (scale: Scale, { direction = 1 }: options = {}) => {
+  if (![-1, 1].includes(direction)) {
+    throw new Error('Direction should be 1 (up) or -1 (down)');
+  }
+
+  if (!isDiatonicScale(scale)) return false;
+
+  if (direction === -1) scale.reverse();
+
+  const normalizedScale = normalizeScale(scale);
+  const intervals = getIntervals(normalizedScale);
+
+  return AEOLIAN.join(',') === intervals.join(',');
+};
+
+export default isMinorScale;

--- a/src/isMinorScale/test.js
+++ b/src/isMinorScale/test.js
@@ -1,0 +1,18 @@
+// https://en.wikipedia.org/wiki/Minor_scale
+
+import isMinorScale from './';
+
+describe('isMinorScale', () => {
+  it('should return true on minor scale ', () => {
+    const scale = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+    expect(isMinorScale(scale)).toBe(true);
+  });
+  it('should return true on minor scale', () => {
+    const scale = ['A1', 'B1', 'C2', 'D2', 'E2', 'F2', 'G2'];
+    expect(isMinorScale(scale)).toBe(true);
+  });
+  it('should return false on major scale ', () => {
+    const scale = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+    expect(isMinorScale(scale)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Added
- `isMajorScale` function
- `isMinorScale` function

---

### Suggestion
Since major is the ionian and minor is the aeolian mode, should we abstract an `isMode` function that allows you to pass a scale and a mode?
That would require us to change the current `isMode` function to something like `isModal`, which describes better what it does imho.

---

Closes #3 
Closes #18 