### PR TITLE
It is good to use one-shot import manner?

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,14 @@ const ignoredFiles = ['constants', 'index.js'];
 
 const musicFunctions = {};
 
+/* eslint-disable  global-require, import/no-dynamic-require */
 fs
   .readdirSync(normalizedPath)
   .filter(file => !ignoredFiles.includes(file))
   .forEach(func => {
     musicFunctions[func] = require(`./${func}`);
   });
+/* eslint-enable */
 
 export default {
   Chord,

--- a/src/index.js
+++ b/src/index.js
@@ -1,68 +1,23 @@
+import path from 'path';
+import fs from 'fs';
+
 import Chord from './constants/Chord';
 import Interval from './constants/Interval';
 import Mode from './constants/Mode';
 import Scale from './constants/Scale';
 import NOTES from './constants/NOTES';
 
-import accidentalToLetter from './accidentalToLetter';
-import accidentalToSymbol from './accidentalToSymbol';
-import areEqual from './areEqual';
-import createChord from './createChord';
-import createMelody from './createMelody';
-import createScale from './createScale';
-import flatToSharp from './flatToSharp';
-import getAccidental from './getAccidental';
-import getChromaticCPosition from './getChromaticCPosition';
-import getDominant from './getDominant';
-import getIntervals from './getIntervals';
-import getLeadingTone from './getLeadingTone';
-import getMediant from './getMediant';
-import getNote from './getNote';
-import getOctave from './getOctave';
-import getRoot from './getRoot';
-import getNoteOnDegree from './getNoteOnDegree';
-import getSubdominant from './getSubdominant';
-import getSubmediant from './getSubmediant';
-import getSupertonic from './getSupertonic';
-import getTonic from './getTonic';
-import hasAccidental from './hasAccidental';
-import hasAccidentalLetter from './hasAccidentalLetter';
-import hasAccidentalSymbol from './hasAccidentalSymbol';
-import hasOctave from './hasOctave';
-import haveSameOctave from './haveSameOctave';
-import isAnhemitonic from './isAnhemitonic';
-import isAscending from './isAscending';
-import isCohemitonic from './isCohemitonic';
-import isDescending from './isDescending';
-import isDiatonic from './isDiatonic';
-import isFifth from './isFifth';
-import isFlat from './isFlat';
-import isHemitonic from './isHemitonic';
-import isHeptatonic from './isHeptatonic';
-import isHexatonic from './isHexatonic';
-import areIntervals from './areIntervals';
-import isMode from './isMode';
-import isNatural from './isNatural';
-import isOctatonic from './isOctatonic';
-import isOctave from './isOctave';
-import isPentatonic from './isPentatonic';
-import isScale from './isScale';
-import hasIntervalAmount from './hasIntervalAmount';
-import isNote from './isNote';
-import areNotes from './areNotes';
-import isSemitone from './isSemitone';
-import isSharp from './isSharp';
-import isTone from './isTone';
-import isTriad from './isTriad';
-import normalize from './normalize';
-import noteToFrequency from './noteToFrequency';
-import noteToMidi from './noteToMidi';
-import noteToObject from './noteToObject';
-import objectToNote from './objectToNote';
-import sharpToFlat from './sharpToFlat';
-import transferAccidental from './transferAccidental';
-import transferStyle from './transferStyle';
-import transpose from './transpose';
+const normalizedPath = path.join(__dirname, './');
+const ignoredFiles = ['constants', 'index.js'];
+
+const musicFunctions = {};
+
+fs
+  .readdirSync(normalizedPath)
+  .filter(file => !ignoredFiles.includes(file))
+  .forEach(func => {
+    musicFunctions[func] = require(`./${func}`);
+  });
 
 export default {
   Chord,
@@ -70,64 +25,5 @@ export default {
   Mode,
   Scale,
   NOTES,
-
-  accidentalToLetter,
-  accidentalToSymbol,
-  areEqual,
-  createChord,
-  createMelody,
-  createScale,
-  flatToSharp,
-  getAccidental,
-  getChromaticCPosition,
-  getDominant,
-  getIntervals,
-  getLeadingTone,
-  getMediant,
-  getNote,
-  getOctave,
-  getRoot,
-  getNoteOnDegree,
-  getSubdominant,
-  getSubmediant,
-  getSupertonic,
-  getTonic,
-  hasAccidental,
-  hasAccidentalLetter,
-  hasAccidentalSymbol,
-  hasOctave,
-  haveSameOctave,
-  isAnhemitonic,
-  isAscending,
-  isCohemitonic,
-  isDescending,
-  isDiatonic,
-  isFifth,
-  isFlat,
-  isHemitonic,
-  isHeptatonic,
-  isHexatonic,
-  areIntervals,
-  isMode,
-  isNatural,
-  isOctatonic,
-  isOctave,
-  isPentatonic,
-  isScale,
-  hasIntervalAmount,
-  isNote,
-  areNotes,
-  isSemitone,
-  isSharp,
-  isTone,
-  isTriad,
-  normalize,
-  noteToFrequency,
-  noteToMidi,
-  noteToObject,
-  objectToNote,
-  sharpToFlat,
-  transferAccidental,
-  transferStyle,
-  transpose
+  ...musicFunctions
 };


### PR DESCRIPTION
I inspect your import and export modules code and see a lot of `import` statements, So there is a good point to use dynamic required to store all modules at once?

**Changed**

- Instead of import all things with `import` statement, I change it to dynamic `require()`.
- Disable ESlint only in at the line of this conduct is needed.

**Tip**
- `const ignoredFiles` can tell us to ignore some modules that we not need.

**Improvement**
- if you export module as same as normal behavioral, all modules will automatically be exported at this point!!