### PR TITLE
Allow common music notation chord names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "music-fns",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "music-fns",
   "version": "0.1.3",
-  "description":
-    "JavaScript music utility library that contains small music notation related functions.",
+  "description": "JavaScript music utility library that contains small music notation related functions.",
   "main": "dist",
   "scripts": {
     "test": "jest",
@@ -20,9 +19,15 @@
   "engines": {
     "node": ">=8"
   },
-  "keywords": ["music", "utility", "audio"],
+  "keywords": [
+    "music",
+    "utility",
+    "audio"
+  ],
   "author": "",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/madewithlove/music-fns/issues"

--- a/src/constants/Chord/AUGMENTED.js
+++ b/src/constants/Chord/AUGMENTED.js
@@ -4,7 +4,10 @@ import { ROOT } from '../Interval/Names';
 import { MAJOR_THIRD } from '../Interval/MinorMajor';
 import { AUGMENTED_FIFTH } from '../Interval/AugmentedDiminished';
 
-const names = ['aug', 'AUGMENTED'];
-const intervals = [ROOT, MAJOR_THIRD, AUGMENTED_FIFTH];
+const AUGMENTED = [ROOT, MAJOR_THIRD, AUGMENTED_FIFTH];
+const aug = AUGMENTED;
 
-export default { names, intervals };
+export default {
+  AUGMENTED,
+  aug
+};

--- a/src/constants/Chord/AUGMENTED.js
+++ b/src/constants/Chord/AUGMENTED.js
@@ -4,4 +4,7 @@ import { ROOT } from '../Interval/Names';
 import { MAJOR_THIRD } from '../Interval/MinorMajor';
 import { AUGMENTED_FIFTH } from '../Interval/AugmentedDiminished';
 
-export default [ROOT, MAJOR_THIRD, AUGMENTED_FIFTH];
+const names = ['aug', 'AUGMENTED'];
+const intervals = [ROOT, MAJOR_THIRD, AUGMENTED_FIFTH];
+
+export default { names, intervals };

--- a/src/constants/Chord/DIMINISHED.js
+++ b/src/constants/Chord/DIMINISHED.js
@@ -4,7 +4,10 @@ import { ROOT } from '../Interval/Names';
 import { MINOR_THIRD } from '../Interval/MinorMajor';
 import { DIMINISHED_FIFTH } from '../Interval/AugmentedDiminished';
 
-const names = ['dim', 'DIMINISHED'];
-const intervals = [ROOT, MINOR_THIRD, DIMINISHED_FIFTH];
+const DIMINISHED = [ROOT, MINOR_THIRD, DIMINISHED_FIFTH];
+const dim = DIMINISHED;
 
-export default { names, intervals };
+export default {
+  DIMINISHED,
+  dim
+};

--- a/src/constants/Chord/DIMINISHED.js
+++ b/src/constants/Chord/DIMINISHED.js
@@ -4,4 +4,7 @@ import { ROOT } from '../Interval/Names';
 import { MINOR_THIRD } from '../Interval/MinorMajor';
 import { DIMINISHED_FIFTH } from '../Interval/AugmentedDiminished';
 
-export default [ROOT, MINOR_THIRD, DIMINISHED_FIFTH];
+const names = ['dim', 'DIMINISHED'];
+const intervals = [ROOT, MINOR_THIRD, DIMINISHED_FIFTH];
+
+export default { names, intervals };

--- a/src/constants/Chord/MAJOR.js
+++ b/src/constants/Chord/MAJOR.js
@@ -3,4 +3,7 @@
 import { ROOT } from '../Interval/Names';
 import { MAJOR_THIRD, PERFECT_FIFTH } from '../Interval/MinorMajor';
 
-export default [ROOT, MAJOR_THIRD, PERFECT_FIFTH];
+const names = ['dur', 'M', 'MAJOR'];
+const intervals = [ROOT, MAJOR_THIRD, PERFECT_FIFTH];
+
+export default { names, intervals };

--- a/src/constants/Chord/MAJOR.js
+++ b/src/constants/Chord/MAJOR.js
@@ -3,7 +3,12 @@
 import { ROOT } from '../Interval/Names';
 import { MAJOR_THIRD, PERFECT_FIFTH } from '../Interval/MinorMajor';
 
-const names = ['dur', 'M', 'MAJOR'];
-const intervals = [ROOT, MAJOR_THIRD, PERFECT_FIFTH];
+const MAJOR = [ROOT, MAJOR_THIRD, PERFECT_FIFTH];
+const dur = MAJOR;
+const M = MAJOR;
 
-export default { names, intervals };
+export default {
+  MAJOR,
+  M,
+  dur
+};

--- a/src/constants/Chord/MAJOR.js
+++ b/src/constants/Chord/MAJOR.js
@@ -3,7 +3,7 @@
 import { ROOT } from '../Interval/Names';
 import { MAJOR_THIRD, PERFECT_FIFTH } from '../Interval/MinorMajor';
 
-const MAJOR = [ROOT, MAJOR_THIRD, PERFECT_FIFTH];
+export const MAJOR = [ROOT, MAJOR_THIRD, PERFECT_FIFTH];
 const dur = MAJOR;
 const M = MAJOR;
 

--- a/src/constants/Chord/MAJOR_SEVENTH.js
+++ b/src/constants/Chord/MAJOR_SEVENTH.js
@@ -1,9 +1,12 @@
 // https://en.wikipedia.org/wiki/Major_seventh_chord
 
 import MAJOR from './MAJOR';
-import { MAJOR_SEVENTH } from '../Interval/MinorMajor';
+import { MAJOR_SEVENTH as MAJOR_SEVENTH_NOTE } from '../Interval/MinorMajor';
 
-const names = ['maj7', 'MAJOR_SEVENTH'];
-const intervals = [...MAJOR.intervals, MAJOR_SEVENTH];
+const MAJOR_SEVENTH = [...MAJOR.intervals, MAJOR_SEVENTH_NOTE];
+const maj7 = MAJOR_SEVENTH;
 
-export default { names, intervals };
+export default {
+  MAJOR_SEVENTH,
+  maj7
+};

--- a/src/constants/Chord/MAJOR_SEVENTH.js
+++ b/src/constants/Chord/MAJOR_SEVENTH.js
@@ -1,9 +1,9 @@
 // https://en.wikipedia.org/wiki/Major_seventh_chord
 
-import MAJOR from './MAJOR';
+import { MAJOR } from './MAJOR';
 import { MAJOR_SEVENTH as MAJOR_SEVENTH_NOTE } from '../Interval/MinorMajor';
 
-const MAJOR_SEVENTH = [...MAJOR.intervals, MAJOR_SEVENTH_NOTE];
+const MAJOR_SEVENTH = [...MAJOR, MAJOR_SEVENTH_NOTE];
 const maj7 = MAJOR_SEVENTH;
 
 export default {

--- a/src/constants/Chord/MAJOR_SEVENTH.js
+++ b/src/constants/Chord/MAJOR_SEVENTH.js
@@ -3,4 +3,7 @@
 import MAJOR from './MAJOR';
 import { MAJOR_SEVENTH } from '../Interval/MinorMajor';
 
-export default [...MAJOR, MAJOR_SEVENTH];
+const names = ['maj7', 'MAJOR_SEVENTH'];
+const intervals = [...MAJOR.intervals, MAJOR_SEVENTH];
+
+export default { names, intervals };

--- a/src/constants/Chord/MINOR.js
+++ b/src/constants/Chord/MINOR.js
@@ -3,7 +3,12 @@
 import { ROOT } from '../Interval/Names';
 import { MINOR_THIRD, PERFECT_FIFTH } from '../Interval/MinorMajor';
 
-const names = ['moll', 'm', 'MINOR'];
-const intervals = [ROOT, MINOR_THIRD, PERFECT_FIFTH];
+const MINOR = [ROOT, MINOR_THIRD, PERFECT_FIFTH];
+const m = MINOR;
+const moll = MINOR;
 
-export default { names, intervals };
+export default {
+  MINOR,
+  m,
+  moll
+};

--- a/src/constants/Chord/MINOR.js
+++ b/src/constants/Chord/MINOR.js
@@ -3,7 +3,7 @@
 import { ROOT } from '../Interval/Names';
 import { MINOR_THIRD, PERFECT_FIFTH } from '../Interval/MinorMajor';
 
-const MINOR = [ROOT, MINOR_THIRD, PERFECT_FIFTH];
+export const MINOR = [ROOT, MINOR_THIRD, PERFECT_FIFTH];
 const m = MINOR;
 const moll = MINOR;
 

--- a/src/constants/Chord/MINOR.js
+++ b/src/constants/Chord/MINOR.js
@@ -3,4 +3,7 @@
 import { ROOT } from '../Interval/Names';
 import { MINOR_THIRD, PERFECT_FIFTH } from '../Interval/MinorMajor';
 
-export default [ROOT, MINOR_THIRD, PERFECT_FIFTH];
+const names = ['moll', 'm', 'MINOR'];
+const intervals = [ROOT, MINOR_THIRD, PERFECT_FIFTH];
+
+export default { names, intervals };

--- a/src/constants/Chord/MINOR_MAJOR_SEVENTH.js
+++ b/src/constants/Chord/MINOR_MAJOR_SEVENTH.js
@@ -3,4 +3,7 @@
 import MINOR from './MINOR';
 import { MAJOR_SEVENTH } from '../Interval/MinorMajor';
 
-export default [...MINOR, MAJOR_SEVENTH];
+const names = ['mM7', 'mΔ7', 'MINOR_MAJOR_SEVENTH'];
+const intervals = [...MINOR.intervals, MAJOR_SEVENTH];
+
+export default { names, intervals };

--- a/src/constants/Chord/MINOR_MAJOR_SEVENTH.js
+++ b/src/constants/Chord/MINOR_MAJOR_SEVENTH.js
@@ -1,9 +1,9 @@
 // https://en.wikipedia.org/wiki/Minor_major_seventh_chord
 
-import MINOR from './MINOR';
+import { MINOR } from './MINOR';
 import { MAJOR_SEVENTH } from '../Interval/MinorMajor';
 
-const MINOR_MAJOR_SEVENTH = [...MINOR.intervals, MAJOR_SEVENTH];
+const MINOR_MAJOR_SEVENTH = [...MINOR, MAJOR_SEVENTH];
 const mM7 = MINOR_MAJOR_SEVENTH;
 const mΔ7 = MINOR_MAJOR_SEVENTH;
 

--- a/src/constants/Chord/MINOR_MAJOR_SEVENTH.js
+++ b/src/constants/Chord/MINOR_MAJOR_SEVENTH.js
@@ -3,7 +3,12 @@
 import MINOR from './MINOR';
 import { MAJOR_SEVENTH } from '../Interval/MinorMajor';
 
-const names = ['mM7', 'mΔ7', 'MINOR_MAJOR_SEVENTH'];
-const intervals = [...MINOR.intervals, MAJOR_SEVENTH];
+const MINOR_MAJOR_SEVENTH = [...MINOR.intervals, MAJOR_SEVENTH];
+const mM7 = MINOR_MAJOR_SEVENTH;
+const mΔ7 = MINOR_MAJOR_SEVENTH;
 
-export default { names, intervals };
+export default {
+  MINOR_MAJOR_SEVENTH,
+  mM7,
+  mΔ7
+};

--- a/src/constants/Chord/MINOR_SEVENTH.js
+++ b/src/constants/Chord/MINOR_SEVENTH.js
@@ -1,9 +1,12 @@
 // https://en.wikipedia.org/wiki/Minor_seventh_chord
 
 import MINOR from './MINOR';
-import { MINOR_SEVENTH } from '../Interval/MinorMajor';
+import { MINOR_SEVENTH as MINOR_SEVENTH_NOTE } from '../Interval/MinorMajor';
 
-const names = ['m7', 'MINOR_SEVENTH'];
-const intervals = [...MINOR.intervals, MINOR_SEVENTH];
+const MINOR_SEVENTH = [...MINOR.intervals, MINOR_SEVENTH_NOTE];
+const m7 = MINOR_SEVENTH;
 
-export default { names, intervals };
+export default {
+  MINOR_SEVENTH,
+  m7
+};

--- a/src/constants/Chord/MINOR_SEVENTH.js
+++ b/src/constants/Chord/MINOR_SEVENTH.js
@@ -1,9 +1,9 @@
 // https://en.wikipedia.org/wiki/Minor_seventh_chord
 
-import MINOR from './MINOR';
+import { MINOR } from './MINOR';
 import { MINOR_SEVENTH as MINOR_SEVENTH_NOTE } from '../Interval/MinorMajor';
 
-const MINOR_SEVENTH = [...MINOR.intervals, MINOR_SEVENTH_NOTE];
+const MINOR_SEVENTH = [...MINOR, MINOR_SEVENTH_NOTE];
 const m7 = MINOR_SEVENTH;
 
 export default {

--- a/src/constants/Chord/MINOR_SEVENTH.js
+++ b/src/constants/Chord/MINOR_SEVENTH.js
@@ -3,4 +3,7 @@
 import MINOR from './MINOR';
 import { MINOR_SEVENTH } from '../Interval/MinorMajor';
 
-export default [...MINOR, MINOR_SEVENTH];
+const names = ['m7', 'MINOR_SEVENTH'];
+const intervals = [...MINOR.intervals, MINOR_SEVENTH];
+
+export default { names, intervals };

--- a/src/constants/Chord/SEVENTH.js
+++ b/src/constants/Chord/SEVENTH.js
@@ -1,9 +1,9 @@
 // https://en.wikipedia.org/wiki/Dominant_seventh_chord
 
-import MAJOR from './MAJOR';
+import { MAJOR } from './MAJOR';
 import { MINOR_SEVENTH } from '../Interval/MinorMajor';
 
-const SEVENTH = [...MAJOR.intervals, MINOR_SEVENTH];
+const SEVENTH = [...MAJOR, MINOR_SEVENTH];
 
 export default {
   SEVENTH,

--- a/src/constants/Chord/SEVENTH.js
+++ b/src/constants/Chord/SEVENTH.js
@@ -3,4 +3,7 @@
 import MAJOR from './MAJOR';
 import { MINOR_SEVENTH } from '../Interval/MinorMajor';
 
-export default [...MAJOR, MINOR_SEVENTH];
+const names = ['7', 'SEVENTH'];
+const intervals = [...MAJOR.intervals, MINOR_SEVENTH];
+
+export default { names, intervals };

--- a/src/constants/Chord/SEVENTH.js
+++ b/src/constants/Chord/SEVENTH.js
@@ -3,7 +3,9 @@
 import MAJOR from './MAJOR';
 import { MINOR_SEVENTH } from '../Interval/MinorMajor';
 
-const names = ['7', 'SEVENTH'];
-const intervals = [...MAJOR.intervals, MINOR_SEVENTH];
+const SEVENTH = [...MAJOR.intervals, MINOR_SEVENTH];
 
-export default { names, intervals };
+export default {
+  SEVENTH,
+  '7': SEVENTH
+};

--- a/src/constants/Chord/helper.js
+++ b/src/constants/Chord/helper.js
@@ -1,3 +1,0 @@
-export default function chordCompiler(names, intervals) {
-  return names.reduce((object, name) => ({ ...object, [name]: intervals }), {});
-}

--- a/src/constants/Chord/helper.js
+++ b/src/constants/Chord/helper.js
@@ -1,0 +1,3 @@
+export default function chordCompiler(names, intervals) {
+  return names.reduce((object, name) => ({ ...object, [name]: intervals }), {});
+}

--- a/src/constants/Chord/index.js
+++ b/src/constants/Chord/index.js
@@ -7,13 +7,17 @@ import MINOR_SEVENTH from './MINOR_SEVENTH';
 import MINOR from './MINOR';
 import SEVENTH from './SEVENTH';
 
+function chordCompiler({ names, intervals }) {
+  return names.reduce((object, name) => ({ ...object, [name]: intervals }), {});
+}
+
 export default {
-  AUGMENTED,
-  DIMINISHED,
-  MAJOR_SEVENTH,
-  MAJOR,
-  MINOR_MAJOR_SEVENTH,
-  MINOR_SEVENTH,
-  MINOR,
-  SEVENTH
+  ...chordCompiler(AUGMENTED),
+  ...chordCompiler(DIMINISHED),
+  ...chordCompiler(MAJOR_SEVENTH),
+  ...chordCompiler(MAJOR),
+  ...chordCompiler(MINOR_MAJOR_SEVENTH),
+  ...chordCompiler(MINOR_SEVENTH),
+  ...chordCompiler(MINOR),
+  ...chordCompiler(SEVENTH)
 };

--- a/src/constants/Chord/index.js
+++ b/src/constants/Chord/index.js
@@ -7,17 +7,13 @@ import MINOR_SEVENTH from './MINOR_SEVENTH';
 import MINOR from './MINOR';
 import SEVENTH from './SEVENTH';
 
-function chordCompiler({ names, intervals }) {
-  return names.reduce((object, name) => ({ ...object, [name]: intervals }), {});
-}
-
 export default {
-  ...chordCompiler(AUGMENTED),
-  ...chordCompiler(DIMINISHED),
-  ...chordCompiler(MAJOR_SEVENTH),
-  ...chordCompiler(MAJOR),
-  ...chordCompiler(MINOR_MAJOR_SEVENTH),
-  ...chordCompiler(MINOR_SEVENTH),
-  ...chordCompiler(MINOR),
-  ...chordCompiler(SEVENTH)
+  ...AUGMENTED,
+  ...DIMINISHED,
+  ...MAJOR_SEVENTH,
+  ...MAJOR,
+  ...MINOR_MAJOR_SEVENTH,
+  ...MINOR_SEVENTH,
+  ...MINOR,
+  ...SEVENTH
 };

--- a/src/constants/Chord/test.js
+++ b/src/constants/Chord/test.js
@@ -1,4 +1,4 @@
-import Chord from './index.js';
+import Chord from './index';
 
 describe('Augmented Chord', () => {
   const pitches = [0, 4, 8];

--- a/src/constants/Chord/test.js
+++ b/src/constants/Chord/test.js
@@ -1,17 +1,14 @@
-import AUGMENTED from './AUGMENTED';
-import DIMINISHED from './DIMINISHED';
-import MAJOR_SEVENTH from './MAJOR_SEVENTH';
-import MAJOR from './MAJOR';
-import MINOR_MAJOR_SEVENTH from './MINOR_MAJOR_SEVENTH';
-import MINOR_SEVENTH from './MINOR_SEVENTH';
-import MINOR from './MINOR';
-import SEVENTH from './SEVENTH';
+import Chord from './index.js';
 
 describe('Augmented Chord', () => {
   const pitches = [0, 4, 8];
 
-  it(`should return ${pitches}`, () => {
-    expect(AUGMENTED).toEqual(pitches);
+  it(`should, for AUGMENTED, return ${pitches}`, () => {
+    expect(Chord.AUGMENTED).toEqual(pitches);
+  });
+
+  it(`should, for "aug", return ${pitches}`, () => {
+    expect(Chord.aug).toEqual(pitches);
   });
 });
 
@@ -19,54 +16,90 @@ describe('Diminished Chord', () => {
   const pitches = [0, 3, 6];
 
   it(`should return ${pitches}`, () => {
-    expect(DIMINISHED).toEqual(pitches);
+    expect(Chord.DIMINISHED).toEqual(pitches);
+  });
+
+  it(`should, for "dim", return ${pitches}`, () => {
+    expect(Chord.dim).toEqual(pitches);
   });
 });
 
 describe('Major Seventh Chord', () => {
   const pitches = [0, 4, 7, 11];
 
-  it(`should return ${pitches}`, () => {
-    expect(MAJOR_SEVENTH).toEqual(pitches);
+  it(`should, for MAJOR_SEVENTH, return ${pitches}`, () => {
+    expect(Chord.MAJOR_SEVENTH).toEqual(pitches);
+  });
+
+  it(`should, for "maj7", return ${pitches}`, () => {
+    expect(Chord.maj7).toEqual(pitches);
   });
 });
 
 describe('Major Chord', () => {
   const pitches = [0, 4, 7];
 
-  it(`should return ${pitches}`, () => {
-    expect(MAJOR).toEqual(pitches);
+  it(`should, for MAJOR, return ${pitches}`, () => {
+    expect(Chord.MAJOR).toEqual(pitches);
+  });
+
+  it(`should, for "M", return ${pitches}`, () => {
+    expect(Chord.M).toEqual(pitches);
+  });
+
+  it(`should, for "dur", return ${pitches}`, () => {
+    expect(Chord.dur).toEqual(pitches);
   });
 });
 
 describe('Minor Major Seventh Chord', () => {
   const pitches = [0, 3, 7, 11];
 
-  it(`should return ${pitches}`, () => {
-    expect(MINOR_MAJOR_SEVENTH).toEqual(pitches);
+  it(`should, for MINOR_MAJOR_SEVENTH, return ${pitches}`, () => {
+    expect(Chord.MINOR_MAJOR_SEVENTH).toEqual(pitches);
+  });
+
+  it(`should, for "mM7", return ${pitches}`, () => {
+    expect(Chord.mM7).toEqual(pitches);
   });
 });
 
 describe('Minor Seventh Chord', () => {
   const pitches = [0, 3, 7, 10];
 
-  it(`should return ${pitches}`, () => {
-    expect(MINOR_SEVENTH).toEqual(pitches);
+  it(`should, for MINOR_SEVENTH, return ${pitches}`, () => {
+    expect(Chord.MINOR_SEVENTH).toEqual(pitches);
+  });
+
+  it(`should, for m7, return ${pitches}`, () => {
+    expect(Chord.m7).toEqual(pitches);
   });
 });
 
 describe('Minor Chord', () => {
   const pitches = [0, 3, 7];
 
-  it(`should return ${pitches}`, () => {
-    expect(MINOR).toEqual(pitches);
+  it(`should, for MINOR, return ${pitches}`, () => {
+    expect(Chord.MINOR).toEqual(pitches);
+  });
+
+  it(`should, for "m", return ${pitches}`, () => {
+    expect(Chord.m).toEqual(pitches);
+  });
+
+  it(`should, for "moll", return ${pitches}`, () => {
+    expect(Chord.moll).toEqual(pitches);
   });
 });
 
 describe('Seventh Chord', () => {
   const pitches = [0, 4, 7, 10];
 
-  it(`should return ${pitches}`, () => {
-    expect(SEVENTH).toEqual(pitches);
+  it(`should, for SEVENTH, return ${pitches}`, () => {
+    expect(Chord.SEVENTH).toEqual(pitches);
+  });
+
+  it(`should, for 7, return ${pitches}`, () => {
+    expect(Chord.SEVENTH).toEqual(pitches);
   });
 });


### PR DESCRIPTION
This rewrites the specification of chords to allow for more names than the constant. For example: maj7, dim etc. This is to easier extend with more special chords later like: 7b9, dim7, 7s9 etc without having awkwardly long constant names.